### PR TITLE
docs: clarify logout behavior

### DIFF
--- a/docs/architecture/bdd steps/bdd-authentication.md
+++ b/docs/architecture/bdd steps/bdd-authentication.md
@@ -38,4 +38,4 @@ Feature: Authentication
   Scenario: User logs out
     Given the user is authenticated
     When the user clicks the logout button
-    Then the session and JWT are cleared and the user is redirected
+    Then the session and JWT are cleared and the user is redirected to the login page


### PR DESCRIPTION
## Summary
- clarify logout scenario in authentication BDD doc to note session and JWT clearance with redirect to login

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a08fff46d0832dae68fb73e40355a1