### PR TITLE
Initialize vertical nav state to avoid runtime crash

### DIFF
--- a/apps/frontend/src/@menu/contexts/verticalNavContext.tsx
+++ b/apps/frontend/src/@menu/contexts/verticalNavContext.tsx
@@ -14,7 +14,7 @@ export type VerticalNavState = {
 }
 
 export type VerticalNavContextProps = VerticalNavState & {
-  updateVerticalNavState: (values: VerticalNavState) => void
+  updateVerticalNavState: (values: Partial<VerticalNavState>) => void
   toggleVerticalNav: (value?: VerticalNavState['isToggled']) => void
 }
 
@@ -22,7 +22,7 @@ const VerticalNavContext = createContext({} as VerticalNavContextProps)
 
 export const VerticalNavProvider = ({ children }: ChildrenType) => {
   // States
-  const [verticalNavState, setVerticalNavState] = useState<VerticalNavState>()
+  const [verticalNavState, setVerticalNavState] = useState<VerticalNavState>({})
 
   // Hooks
   const updateVerticalNavState = useCallback((values: Partial<VerticalNavState>) => {


### PR DESCRIPTION
## Summary
- initialize vertical nav state with an empty object to avoid spreading undefined
- type `updateVerticalNavState` to accept partial updates

## Testing
- `npm run lint`
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a06828ad00832d86f3a08189e7651e