### PR TITLE
fix: remove duplicate anchor ref in user dropdown

### DIFF
--- a/apps/frontend/src/components/layout/shared/UserDropdown.tsx
+++ b/apps/frontend/src/components/layout/shared/UserDropdown.tsx
@@ -36,7 +36,7 @@ const UserDropdown = () => {
   const [open, setOpen] = useState(false)
 
   // Refs
-  const anchorRef = useRef<HTMLDivElement>(null)
+  const anchorRef = useRef<HTMLElement | null>(null)
 
   // Hooks
   const router = useRouter()
@@ -67,7 +67,6 @@ const UserDropdown = () => {
         className='mis-2'
       >
         <Avatar
-          ref={anchorRef}
           alt='John Doe'
           src='/images/avatars/1.png'
           onClick={handleDropdownOpen}


### PR DESCRIPTION
## Summary
- keep a single anchor ref on the badge in UserDropdown
- remove duplicate ref from Avatar and anchor Popper to badge

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a09254dc1c832db59d7baf1b2d36b3